### PR TITLE
6 has claimable fees

### DIFF
--- a/src/pages/ManageWallet/ManageWallet.tsx
+++ b/src/pages/ManageWallet/ManageWallet.tsx
@@ -54,6 +54,7 @@ const ManageWallet: FC<ManageWalletProps> = memo(
 			collatRatio,
 			targetRatio,
 			isFeesClaimable,
+			hasFeesToClaim,
 			maxIssuableSynths,
 			sUSDBalance,
 		} = walletInfo;
@@ -156,7 +157,7 @@ const ManageWallet: FC<ManageWalletProps> = memo(
 					<Button
 						size="lg"
 						palette="primary"
-						disabled={isFeesClaimable === false || isLoading}
+						disabled={isFeesClaimable === false || hasFeesToClaim === false || isLoading}
 						onClick={handleClaimFees}
 					>
 						{t('manage-wallet.buttons.claim-fees')}
@@ -266,6 +267,7 @@ const mapStateToProps = (state: RootState, { match }: Props): StateProps => {
 					collatRatio: null,
 					targetRatio: null,
 					isFeesClaimable: false,
+					hasFeesToClaim: false,
 					maxIssuableSynths: null,
 					sUSDBalance: null,
 			  },

--- a/src/store/ducks/delegates/delegateWalletInfo.ts
+++ b/src/store/ducks/delegates/delegateWalletInfo.ts
@@ -50,18 +50,19 @@ export const fetchDelegateWalletInfoRequest: ActionCreatorWithPayload<{
 	walletAddresses: WalletAddresses;
 }> = fetchRequest;
 
+interface DelegateWalletData {
+	collateralisationRatio: BigNumberish;
+	issuanceRatio: BigNumberish;
+	maxIssueSynths: BigNumberish;
+	isFeesClaimable: boolean;
+	feesAvailable: [BigNumberish, BigNumberish];
+	sUSDBalance: number;
+}
+
 function* fetchDelegateWalletInfo(walletAddr: WalletAddress) {
 	const {
 		snxJS: { Synthetix, SynthetixState, FeePool, sUSD },
 	} = snxJSConnector;
-	type DelegateWalletData = {
-		collateralisationRatio: BigNumberish;
-		issuanceRatio: BigNumberish;
-		maxIssueSynths: BigNumberish;
-		isFeesClaimable: boolean;
-		feesAvailable: [BigNumberish, BigNumberish];
-		sUSDBalance: number;
-	};
 
 	const delegateData: DelegateWalletData = yield all({
 		collateralisationRatio: call(Synthetix.collateralisationRatio, walletAddr),
@@ -87,19 +88,11 @@ function* fetchDelegateWalletInfo(walletAddr: WalletAddress) {
 		[walletAddr]: {
 			collatRatio:
 				collateralisationRatio > 0
-					? Math.round(
-							toBigNumber(100)
-								.dividedBy(formatEther(collateralisationRatio))
-								.toNumber()
-					  )
+					? Math.round(toBigNumber(100).dividedBy(formatEther(collateralisationRatio)).toNumber())
 					: 0,
 			targetRatio:
 				issuanceRatio > 0
-					? Math.round(
-							toBigNumber(100)
-								.dividedBy(formatEther(issuanceRatio))
-								.toNumber()
-					  )
+					? Math.round(toBigNumber(100).dividedBy(formatEther(issuanceRatio)).toNumber())
 					: 0,
 			maxIssuableSynths: Number(formatEther(maxIssueSynths)),
 			isFeesClaimable,
@@ -115,7 +108,7 @@ function* fetchDelegateWalletsInfo(action: PayloadAction<{ walletAddresses: Wall
 	try {
 		const { walletAddresses } = action.payload;
 
-		yield all(walletAddresses.map(walletAddr => fetchDelegateWalletInfo(walletAddr)));
+		yield all(walletAddresses.map((walletAddr) => fetchDelegateWalletInfo(walletAddr)));
 	} catch (e) {
 		yield put(fetchDelegateWalletInfoFailure({ error: e.message }));
 	}

--- a/src/store/ducks/delegates/delegateWalletInfo.ts
+++ b/src/store/ducks/delegates/delegateWalletInfo.ts
@@ -18,6 +18,7 @@ export interface DelegateWalletInfo {
 	maxIssuableSynths: number | null;
 	isFeesClaimable: boolean;
 	sUSDBalance: number | null;
+	hasFeesToClaim: boolean;
 }
 
 export type DelegateWalletsInfo = Record<WalletAddress, DelegateWalletInfo>;
@@ -58,6 +59,8 @@ function* fetchDelegateWalletInfo(walletAddr: WalletAddress) {
 	const issuanceRatio: BigNumberish = yield SynthetixState.issuanceRatio();
 	const maxIssueSynths: BigNumberish = yield Synthetix.maxIssuableSynths(walletAddr);
 	const isFeesClaimable: boolean = yield FeePool.isFeesClaimable(walletAddr);
+	const feesAvailable: Array<BigNumberish> = yield FeePool.feesAvailable(walletAddr);
+	const [sUSDExchangeFees, SNXRewards] = feesAvailable.map(formatEther);
 	const sUSDBalance: number = yield sUSD.balanceOf(walletAddr);
 
 	const data = {
@@ -80,6 +83,7 @@ function* fetchDelegateWalletInfo(walletAddr: WalletAddress) {
 					: 0,
 			maxIssuableSynths: Number(formatEther(maxIssueSynths)),
 			isFeesClaimable,
+			hasFeesToClaim: Boolean(Number(sUSDExchangeFees) !== 0 || Number(SNXRewards) !== 0),
 			sUSDBalance: Number(sUSDBalance),
 		},
 	};


### PR DESCRIPTION
Added new field `hasFeesToClaim` to `DelegateWalletInfo`. 
If we have `sUSDExchangeFees` or `SNXRewards` to collect this field will be set to true.
If it's not true the claim button will be disabled.

I also used redux sagas `all` function to fetch data in parallel. If there is a reason we didn't do this I can just remove the second commit.

Fixes both #6  and #7 