### PR TITLE
4 ether scan links

### DIFF
--- a/src/pages/ManageWallet/ManageWallet.tsx
+++ b/src/pages/ManageWallet/ManageWallet.tsx
@@ -171,9 +171,9 @@ const ManageWallet: FC<ManageWalletProps> = memo(
 								</TransactionHeadingWrapper>
 							</CollatBoxLabel>
 
-							<Link isExternal to={transactionHashToLink(transaction.hash, networkName)}>
+							<TransactionLink isExternal to={transactionHashToLink(transaction.hash, networkName)}>
 								{transactionHashToLink(transaction.hash, networkName)}
-							</Link>
+							</TransactionLink>
 						</CollatBox>
 					);
 				})}
@@ -250,6 +250,11 @@ const TransactionHeadingWrapper = styled.div`
 `;
 const TransactionSpinner = styled(Spinner)`
 	margin-left: 10px;
+`;
+const TransactionLink = styled(Link)`
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 `;
 
 const CollatBox = styled.div`

--- a/src/pages/ManageWallet/ManageWallet.tsx
+++ b/src/pages/ManageWallet/ManageWallet.tsx
@@ -161,22 +161,23 @@ const ManageWallet: FC<ManageWalletProps> = memo(
 				<PageLogo size="sm" />
 				<PageHeadline size="sm">{t('manage-wallet.headline')}</PageHeadline>
 				<Wallet>{toShortWalletAddr(walletAddr)}</Wallet>
-				{transactions.map(transaction => {
-					return (
-						<CollatBox key={transaction.hash}>
-							<CollatBoxLabel>
-								<TransactionHeadingWrapper>
-									{t('manage-wallet.transaction')}
-									<TransactionSpinner />
-								</TransactionHeadingWrapper>
-							</CollatBoxLabel>
+				{transactions.map(transaction => (
+					<CollatBox key={transaction.hash}>
+						<CollatBoxLabel>
+							<TransactionHeadingWrapper>
+								{t('manage-wallet.transaction')}
+								<TransactionSpinner />
+							</TransactionHeadingWrapper>
+						</CollatBoxLabel>
 
-							<TransactionLink isExternal to={transactionHashToLink(transaction.hash, networkName)}>
-								{transactionHashToLink(transaction.hash, networkName)}
-							</TransactionLink>
-						</CollatBox>
-					);
-				})}
+						<TransactionLink
+							isExternal={true}
+							to={transactionHashToLink(transaction.hash, networkName)}
+						>
+							{transactionHashToLink(transaction.hash, networkName)}
+						</TransactionLink>
+					</CollatBox>
+				))}
 				<CollatBox>
 					<CollatBoxLabel>{t('manage-wallet.current-c-ratio')}</CollatBoxLabel>
 					<CollatBoxValue>{collatRatio != null ? `${collatRatio}%` : EMPTY_VALUE}</CollatBoxValue>

--- a/src/store/ducks/transaction/actionTransactions.ts
+++ b/src/store/ducks/transaction/actionTransactions.ts
@@ -1,0 +1,91 @@
+import { takeEvery, call, put } from 'redux-saga/effects';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from 'store/types';
+import snxJSConnector from 'utils/snxJSConnector';
+import { fetchDelegateWalletInfoRequest } from '../delegates/delegateWalletInfo';
+
+export interface Transaction {
+	hash: string;
+}
+export interface TransactionError {
+	errorMessageKey: string;
+	// Id might be a hash, but if we failed before getting a hash another id string
+	id: string;
+}
+
+type ActionTransactionState = {
+	byHash: Record<string, Transaction>;
+	errorsById: Record<string, TransactionError>;
+};
+const initialState: ActionTransactionState = {
+	byHash: {},
+	errorsById: {},
+};
+
+const sliceName = 'actionTransactions';
+
+export const gasInfoSlice = createSlice({
+	name: sliceName,
+	initialState,
+	reducers: {
+		addTransaction: (
+			state,
+			action: PayloadAction<{
+				hash: string;
+				walletAddress: string;
+			}>
+		) => {
+			const { hash } = action.payload;
+			state.byHash[hash] = { hash };
+		},
+		removeTransaction: (
+			state,
+			action: PayloadAction<{
+				hash: string;
+			}>
+		) => {
+			const { hash } = action.payload;
+			delete state.byHash[hash];
+		},
+		addError: (state, action: PayloadAction<TransactionError>) => {
+			const { id, errorMessageKey } = action.payload;
+			state.errorsById[id] = { errorMessageKey, id };
+		},
+		removeError: (
+			state,
+			action: PayloadAction<{
+				id: string;
+			}>
+		) => {
+			const { id } = action.payload;
+			delete state.errorsById[id];
+		},
+	},
+});
+
+export const { addTransaction, removeTransaction, addError, removeError } = gasInfoSlice.actions;
+
+export const getActionTransactionState = (state: RootState) => state.transaction[sliceName];
+export const getTransactions = (state: RootState) =>
+	Object.values(getActionTransactionState(state).byHash);
+
+export const getErrors = (state: RootState) =>
+	Object.values(getActionTransactionState(state).errorsById);
+
+function* addTransactionSaga(action: PayloadAction<{ hash: string; walletAddress: string }>) {
+	const { hash, walletAddress } = action.payload;
+	const status = yield call(snxJSConnector.utils.waitForTransaction, hash);
+	if (status === 'error') {
+		yield put(addError({ id: hash, errorMessageKey: 'common.errors.unknown-error-try-again' }));
+	} else {
+		yield put(removeError({ id: hash }));
+		yield put(fetchDelegateWalletInfoRequest({ walletAddresses: [walletAddress] }));
+	}
+	yield put(removeTransaction({ hash }));
+}
+
+export function* watchAddTransaction() {
+	yield takeEvery(addTransaction.type, addTransactionSaga);
+}
+
+export default gasInfoSlice.reducer;

--- a/src/store/ducks/transaction/actionTransactions.ts
+++ b/src/store/ducks/transaction/actionTransactions.ts
@@ -1,5 +1,5 @@
 import { takeEvery, call, put } from 'redux-saga/effects';
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, createSelector } from '@reduxjs/toolkit';
 import { RootState } from 'store/types';
 import snxJSConnector from 'utils/snxJSConnector';
 import { fetchDelegateWalletInfoRequest } from '../delegates/delegateWalletInfo';
@@ -24,7 +24,7 @@ const initialState: ActionTransactionState = {
 
 const sliceName = 'actionTransactions';
 
-export const gasInfoSlice = createSlice({
+export const actionTransactionsSlice = createSlice({
 	name: sliceName,
 	initialState,
 	reducers: {
@@ -63,14 +63,22 @@ export const gasInfoSlice = createSlice({
 	},
 });
 
-export const { addTransaction, removeTransaction, addError, removeError } = gasInfoSlice.actions;
+export const {
+	addTransaction,
+	removeTransaction,
+	addError,
+	removeError,
+} = actionTransactionsSlice.actions;
 
-export const getActionTransactionState = (state: RootState) => state.transaction[sliceName];
-export const getTransactions = (state: RootState) =>
-	Object.values(getActionTransactionState(state).byHash);
+const getActionTransactionState = (state: RootState) => state.transaction[sliceName];
 
-export const getErrors = (state: RootState) =>
-	Object.values(getActionTransactionState(state).errorsById);
+export const getTransactions = createSelector(getActionTransactionState, transactionState =>
+	Object.values(transactionState.byHash)
+);
+
+export const getErrors = createSelector(getActionTransactionState, transactionState =>
+	Object.values(transactionState.errorsById)
+);
 
 function* addTransactionSaga(action: PayloadAction<{ hash: string; walletAddress: string }>) {
 	const { hash, walletAddress } = action.payload;
@@ -88,4 +96,4 @@ export function* watchAddTransaction() {
 	yield takeEvery(addTransaction.type, addTransactionSaga);
 }
 
-export default gasInfoSlice.reducer;
+export default actionTransactionsSlice.reducer;

--- a/src/store/ducks/transaction/index.ts
+++ b/src/store/ducks/transaction/index.ts
@@ -2,8 +2,10 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import gasInfo from './gasInfo';
 import gasPrice from './gasPrice';
+import actionTransactions from './actionTransactions';
 
 export default combineReducers({
 	gasInfo,
 	gasPrice,
+	actionTransactions,
 });

--- a/src/store/rootSaga.ts
+++ b/src/store/rootSaga.ts
@@ -3,12 +3,14 @@ import { all } from 'redux-saga/effects';
 import { watchFetchGasPriceRequest } from './ducks/transaction/gasPrice';
 import { watchFetchDelegateWalletsRequest } from './ducks/delegates/delegateWallets';
 import { watchFetchDelegateWalletInfoRequest } from './ducks/delegates/delegateWalletInfo';
+import { watchAddTransaction } from './ducks/transaction/actionTransactions';
 
 const rootSaga = function*() {
 	yield all([
 		watchFetchDelegateWalletsRequest(),
 		watchFetchGasPriceRequest(),
 		watchFetchDelegateWalletInfoRequest(),
+		watchAddTransaction(),
 	]);
 };
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -14,6 +14,7 @@
 		"headline": "Delegation enables a wallet to execute functions on behalf of another wallet: mint, burn, claim, and exchange.",
 		"current-c-ratio": "current c-ratio",
 		"target-c-ratio": "target c-ratio",
+		"transaction": "Transaction",
 		"buttons": {
 			"burn-to-target": "Burn to target",
 			"claim-fees": "Claim fees",

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,6 +1,7 @@
 import { toBigNumber } from './math';
 
 import { GWEI_UNIT, GAS_LIMIT_BUFFER } from 'constants/transaction';
+import { SupportedNetworkName } from 'constants/network';
 
 export const calcTxPrice = (gasPrice: number, gasLimit: number, ethPrice: number) =>
 	toBigNumber(gasPrice)
@@ -18,3 +19,8 @@ export const gweiGasPrice = (gasPrice: number) =>
 	toBigNumber(gasPrice)
 		.multipliedBy(GWEI_UNIT)
 		.toNumber();
+
+export const transactionHashToLink = (hash: string, networkName: SupportedNetworkName) => {
+	const subDomain = networkName === 'MAINNET' ? '' : networkName.toLowerCase() + '.';
+	return `https://${subDomain}etherscan.io/tx/${hash}`;
+};


### PR DESCRIPTION
This is a sorta big PR, so I recommend reviewing each commit. I tried to make them easy to follow.

I created a new slice to manage "action" transations, which can be mint, claim or burn to target.
The slice also manages errors.  

The `addTransaction` saga will first add the transaction hash to state, the ui can then show the etherscan link.
Then it will wait for the transaction to finish using `snxJSConnector.utils.waitForTransaction`.
If everything went well it will call `fetchDelegateWalletInfoRequest`
If there's an error that will also be handled.

I made it so you can do multiple transactions just like you can in mintr. 

This should solve #2, #4 and #5. But it was a little hard to test, would love some help with that.

![Screen Shot 2020-04-13 at 10 15 33 pm](https://user-images.githubusercontent.com/5688912/79685495-a0969480-827c-11ea-8263-66102580486b.png)
![Screen Shot 2020-04-13 at 10 15 13 pm](https://user-images.githubusercontent.com/5688912/79685497-a5f3df00-827c-11ea-8a4f-d3e2f3aa41ce.png)
Elipsis for long links:
![Screen Shot 2020-04-19 at 8 12 31 pm](https://user-images.githubusercontent.com/5688912/79685502-a8eecf80-827c-11ea-8f78-4948092936f8.png)


